### PR TITLE
Add the ability to queue indexes.

### DIFF
--- a/app/code/local/Aoe/Index/Block/Adminhtml/Index/Process/Grid.php
+++ b/app/code/local/Aoe/Index/Block/Adminhtml/Index/Process/Grid.php
@@ -42,8 +42,35 @@ class Aoe_Index_Block_Adminhtml_Index_Process_Grid extends Mage_Index_Block_Admi
 		));
 		$this->_columnsOrder['started_at'] = 'update_required';
 
-
 		parent::_prepareColumns();
+
+        if (Mage::getConfig()->getModuleConfig('Aoe_Scheduler')->is('active', 'true'))
+        {
+            $this->removeColumn('action');
+            $this->addColumn('action',
+                array(
+                    'header'    =>  Mage::helper('index')->__('Action'),
+                    'width'     => '100',
+                    'type'      => 'action',
+                    'getter'    => 'getId',
+                    'actions'   => array(
+                        array(
+                            'caption'   => Mage::helper('index')->__('Reindex Data'),
+                            'url'       => array('base'=> '*/*/reindexProcess'),
+                            'field'     => 'process'
+                        ),
+                        array(
+                            'caption'   => Mage::helper('index')->__('Queue Reindex'),
+                            'url'       => array('base'=> '*/*/queueProcess'),
+                            'field'     => 'process'
+                        ),
+                    ),
+                    'filter'    => false,
+                    'sortable'  => false,
+                    'is_system' => true,
+            ));
+        }
+
 		$this->getColumn('ended_at')->setData('ageBase','started_at' );
 		$this->getColumn('ended_at')->setData('ageDescription','(Took %s)' );
 		$this->getColumn('ended_at')->setData('renderer','Aoe_Index_Block_Adminhtml_Grid_Column_Renderer_Datetime' );
@@ -51,4 +78,19 @@ class Aoe_Index_Block_Adminhtml_Index_Process_Grid extends Mage_Index_Block_Admi
 	}
 
 
+    protected function _prepareMassaction()
+    {
+        parent::_prepareMassaction();
+
+        if (Mage::getConfig()->getModuleConfig('Aoe_Scheduler')->is('active', 'true'))
+        {
+            $this->getMassactionBlock()->addItem('queue', array(
+                'label'    => Mage::helper('index')->__('Queue Reindex'),
+                'url'      => $this->getUrl('*/*/massQueue'),
+                'selected' => true,
+            ));
+        }
+
+        return $this;
+    }
 }

--- a/app/code/local/Aoe/Index/Model/Observer.php
+++ b/app/code/local/Aoe/Index/Model/Observer.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Aoe_Index
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the H&O Commercial License
+ * that is bundled with this package in the file LICENSE_HO.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.h-o.nl/license
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to info@h-o.com so we can send you a copy immediately.
+ *
+ * @category    Aoe
+ * @package     Aoe_Index
+ * @copyright   Copyright © 2013 H&O (http://www.h-o.nl/)
+ * @license     H&O Commercial License (http://www.h-o.nl/license)
+ * @author      Paul Hachmang – H&O <info@h-o.nl>
+ *
+ * 
+ */
+ 
+class Aoe_Index_Model_Observer
+{
+    const CRON_STRING_PATH  = 'crontab/jobs/index_%s/schedule/cron_expr';
+    const CRON_MODEL_PATH   = 'crontab/jobs/index_%s/run/model';
+    const CRON_MODEL_EXPR   = 'aoe_index/observer::process';
+    const CRON_PREFIX       = 'index';
+
+    public function process($event)
+    {
+        $jobCode = str_replace(self::CRON_PREFIX.'_','',$event->getJobCode());
+
+        /* @var $process Aoe_Index_Model_Process */
+        $process = Mage::getModel('index/process')->load($jobCode, 'indexer_code');
+
+        if ($process) {
+            try {
+                Varien_Profiler::start('__INDEX_PROCESS_REINDEX_ALL__');
+                $process->reindexEverything();
+                Varien_Profiler::stop('__INDEX_PROCESS_REINDEX_ALL__');
+
+                return;
+
+            } catch (Mage_Core_Exception $e) {
+                return $e->getMessage();
+            } catch (Exception $e) {
+                return $e;
+            }
+        } else {
+            return Mage::helper('index')->__('Cannot initialize the indexer process.');
+        }
+    }
+}

--- a/app/code/local/Aoe/Index/Model/Observer.php
+++ b/app/code/local/Aoe/Index/Model/Observer.php
@@ -41,15 +41,14 @@ class Aoe_Index_Model_Observer
                 $process->reindexEverything();
                 Varien_Profiler::stop('__INDEX_PROCESS_REINDEX_ALL__');
 
-                return;
-
+                return '';
             } catch (Mage_Core_Exception $e) {
-                return $e->getMessage();
+                return 'ERROR: '.$e->getMessage();
             } catch (Exception $e) {
-                return $e;
+                return 'ERROR: '.$e;
             }
         } else {
-            return Mage::helper('index')->__('Cannot initialize the indexer process.');
+            return 'ERROR: '.Mage::helper('index')->__('Cannot initialize the indexer process.');
         }
     }
 }

--- a/app/code/local/Aoe/Index/controllers/Adminhtml/ProcessController.php
+++ b/app/code/local/Aoe/Index/controllers/Adminhtml/ProcessController.php
@@ -4,16 +4,98 @@ require("app/code/core/Mage/Index/controllers/Adminhtml/ProcessController.php");
 class Aoe_Index_Adminhtml_ProcessController extends Mage_Index_Adminhtml_ProcessController
 {
 
-
-    /**
-     * Display processes grid action
-     */
-    public function listAction()
+    public function queueProcessAction()
     {
-        $this->_title($this->__('System'))->_title($this->__('Index Management'));
+        $process = $this->_initProcess();
+        if ($process) {
+            Mage::getModel('cron/schedule') /* @var Aoe_Scheduler_Model_Schedule */
+                ->setJobCode(Aoe_Index_Model_Observer::CRON_PREFIX.'_'.$process->getIndexerCode())
+                ->schedule()
+                ->save();
 
-        $this->loadLayout();
-        $this->_setActiveMenu('system/index');
-        $this->renderLayout();
+            $this->_getSession()->addSuccess(
+                Mage::helper('index')->__('%s index was queued for reindexing.', $process->getIndexer()->getName())
+            );
+        } else {
+            $this->_getSession()->addError(
+                Mage::helper('index')->__('Cannot initialize the indexer process.')
+            );
+        }
+
+        $this->_redirect('*/*/list');
     }
+
+    public function massQueueAction()
+    {
+        /* @var $indexer Mage_Index_Model_Indexer */
+        $indexer    = Mage::getSingleton('index/indexer');
+        $processIds = $this->getRequest()->getParam('process');
+        if (empty($processIds) || !is_array($processIds)) {
+            $this->_getSession()->addError(Mage::helper('index')->__('Please select Indexes'));
+        } else {
+            try {
+                foreach ($processIds as $processId) {
+                    $process = $this->_initProcess($processId);
+                    if ($process) {
+                        Mage::getModel('cron/schedule') /* @var Aoe_Scheduler_Model_Schedule */
+                            ->setJobCode(Aoe_Index_Model_Observer::CRON_PREFIX.'_'.$process->getIndexerCode())
+                            ->schedule()
+                            ->save();
+                        $this->_getSession()->addSuccess(
+                            Mage::helper('index')->__('%s index was queued for reindexing.', $process->getIndexer()->getName())
+                        );
+                    }
+                }
+                $count = count($processIds);
+                $this->_getSession()->addSuccess(
+                    Mage::helper('index')->__('Total of %d index(es) have been queued for reindexing.', $count)
+                );
+            } catch (Mage_Core_Exception $e) {
+                $this->_getSession()->addError($e->getMessage());
+            } catch (Exception $e) {
+                $this->_getSession()->addException($e, Mage::helper('index')->__('Cannot initialize the indexer process.'));
+            }
+        }
+
+        $this->_redirect('*/*/list');
+    }
+
+
+    protected function _initProcess($processId = null)
+    {
+        $processId = $processId ? $processId : $this->getRequest()->getParam('process');
+        if ($processId) {
+            $process = Mage::getModel('index/process')->load($processId);
+            if (! $process->getId()) {
+                return false;
+            }
+        } else {
+            return false;
+        }
+
+        try {
+            $cronExpr = sprintf(Aoe_Index_Model_Observer::CRON_STRING_PATH, $process->getIndexerCode());
+            Mage::getModel('core/config_data')
+                ->load($cronExpr, 'path')
+                ->setValue('')
+                ->setPath($cronExpr)
+                ->save();
+
+            $model = sprintf(Aoe_Index_Model_Observer::CRON_MODEL_PATH, $process->getIndexerCode());
+            Mage::getModel('core/config_data')
+                ->load($model, 'path')
+                ->setValue(Aoe_Index_Model_Observer::CRON_MODEL_EXPR)
+                ->setPath($model)
+                ->save();
+
+            Mage::getConfig()->cleanCache();
+        }
+        catch (Exception $e) {
+            Mage::throwException(Mage::helper('adminhtml')->__('Unable to save the cron expression.'));
+        }
+
+        return $process;
+    }
+
+
 }

--- a/app/code/local/Aoe/Index/etc/config.xml
+++ b/app/code/local/Aoe/Index/etc/config.xml
@@ -41,7 +41,7 @@
 			<adminhtml>
 				<args>
 					<modules>
-						<!--<Aoe_Index before="Mage_Index">Aoe_Index_Adminhtml</Aoe_Index>-->
+						<Aoe_Index before="Mage_Index">Aoe_Index_Adminhtml</Aoe_Index>
 					</modules>
 				</args>
 			</adminhtml>


### PR DESCRIPTION
For a current project we deal with a lot of products. Therefor the indexing process takes a long time but does finish properly, great!

The problem arose when the internetconnection wasn't as stable as it should have been, meaning that the SSH-pipe broke and the indexing stop. Of course we can /dev/null the script, but that still requires me to do it via the terminal. This frustrated me a long time that it is possible to reindex the indexes in the admin panel, but you aren't able to schedule them.

I've added the ability to schedule an index so it is executed when the cron runs. You can now select `Queue Reindex` for each index or massQueue them all at once. The queue ability is depended on Aoe_Scheduler (normal schedule module doesn't have the scheduleNow method). If Aoe_Scheduler isn't installed this functionality is hidden.

If you guys can accept the pull request or at least provide feedback, that'd be cool :)
